### PR TITLE
Explicit coerce to Maybe

### DIFF
--- a/goodies/Func.hx
+++ b/goodies/Func.hx
@@ -279,7 +279,7 @@ class Func {
     public static inline function find<S>(f:S->Bool, xs:Array<S>):Maybe<S> {
         var ret = null;
         for (x in xs) if (f(x)) { ret = x; break; }
-        return ret;
+        return new Maybe(ret);
     }
     public static inline function filter<S>(f:S->Bool, xs:Array<S>):Array<S> {
         var ys = [];


### PR DESCRIPTION
Disclaimer, I'm extremely new to Haxe!

It seems "find" can't coerce its return value to a Maybe. Without this change I get this error:

/usr/lib/haxe/lib/goodies/0,2,1/goodies/Func.hx:282: characters 15-18 : find.S should be goodies.Maybe< find.S >

I'm using haxe 3.0.0 on a mac, compiling to flash.
